### PR TITLE
F2F-727 Reverse: Removed dns resource conditionals so there's only one url

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -577,14 +577,7 @@ Resources:
   IPRFrontCustomDomain:
     Type: AWS::ApiGatewayV2::DomainName
     Properties:
-      DomainName: !If
-        - IsNotDevelopment
-        - !Sub
-          - "www.${DNSSUFFIX}"
-          - DNSSUFFIX: !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
-        - !Sub
-          - "${AWS::StackName}.${DNSSUFFIX}"
-          - DNSSUFFIX: !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
+      DomainName: !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
       DomainNameConfigurations:
         - CertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
           EndpointType: REGIONAL
@@ -593,14 +586,7 @@ Resources:
   IPRFrontApiRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      Name: !If
-        - IsNotDevelopment
-        - !Sub
-          - "www.${DNSSUFFIX}"
-          - DNSSUFFIX: !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
-        - !Sub
-          - "${AWS::StackName}.${DNSSUFFIX}"
-          - DNSSUFFIX: !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
+      Name: !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
       Type: A
       HostedZoneId: !ImportValue PublicHostedZoneId
       AliasTarget:


### PR DESCRIPTION
### What changed

Removed dns domain name and record set conditional which allowed multiple domains for test stacks. 

Additional default url changed from https://www.return.dev.account.gov.uk/ to https://www.ipvreturn-front.return.dev.account.gov.uk/ which was causing problems and needed to be reversed.

### Issue tracking

Reversing work from ticket below
- [F2F-727](https://govukverify.atlassian.net/browse/F2F-727)

