### PR TITLE
F2F-651: Enable WAF for FE Load Balancer

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -530,11 +530,11 @@ Resources:
           "protocol":"$context.protocol",
           "responseLength":"$context.responseLength"
           }
-  # WAFv2ACLAssociation:
-  #   Type: AWS::WAFv2::WebACLAssociation
-  #   Properties:
-  #     ResourceArn: !Ref LoadBalancer
-  #     WebACLArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Security/WafArn}}"
+  WAFv2ACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Ref LoadBalancer
+      WebACLArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Security/WafArn}}"
 
   APIGWAccessLogsGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
- Add Load Balancer Association for Block mode WAF found in infra repository
- Remove redundant WAF template file
- [F2F-651](https://govukverify.atlassian.net/browse/F2F-651)
