### PR TITLE
[F2F-1014]: Invalid urls saved into the IPR Session table from before the Auth client registry was updated

### DIFF
--- a/src/controller/ReturnController.ts
+++ b/src/controller/ReturnController.ts
@@ -5,6 +5,7 @@ import { EnvironmentVariables } from "../utils/EnvironmentVariables";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 import { loggingHelper } from "../utils/LoggingHelper";
 import axios, { AxiosResponse } from "axios";
+import { Constants } from "../utils/Constants";
 
 export class ReturnController {
 
@@ -70,14 +71,15 @@ export class ReturnController {
     				if (resp.data && resp.status === 200 &&
 						resp.data.redirect_uri && resp.data.status === "completed") {
     					loggingHelper.info("Redirecting to RelyingParty", { "redirectUri":resp.data?.redirect_uri });
-						const rpUrl = new URL(resp.data.redirect_uri);
+    					const rpUrl = new URL(resp.data.redirect_uri);
 
-						//To handle audit events that were generated from these RPs before updated to registry was made
-						//https://govukverify.atlassian.net/browse/F2F-958
-						if (!rpUrl.hostname.startsWith("www") &&
-							(rpUrl.hostname === "apply-basic-criminal-record-check.service.gov.uk" || rpUrl.hostname === "vehicle-operator-licensing.service.gov.uk") ) {
-							rpUrl.hostname = "www" + "." + rpUrl.hostname;
-						}
+    					//To handle audit events that were generated from these RPs before updated to registry was made
+    					//https://govukverify.atlassian.net/browse/F2F-958
+    					if (!rpUrl.hostname.startsWith("www") &&
+							(rpUrl.hostname === Constants.DBS_BASE_URL || rpUrl.hostname === Constants.DVLA_BASE_URL) ) {
+    						loggingHelper.info("Found DBS or DVLA hostname without www in redirect url hence appending it");
+    						rpUrl.hostname = "www" + "." + rpUrl.hostname;
+    					}
     					res.redirect(rpUrl.toString());
     				} else {
     					this.redirectToDashboard(res, "Received no data, missing mandatory params in response or statusCode other than 200" );

--- a/src/controller/ReturnController.ts
+++ b/src/controller/ReturnController.ts
@@ -70,7 +70,15 @@ export class ReturnController {
     				if (resp.data && resp.status === 200 &&
 						resp.data.redirect_uri && resp.data.status === "completed") {
     					loggingHelper.info("Redirecting to RelyingParty", { "redirectUri":resp.data?.redirect_uri });
-    					res.redirect(resp.data.redirect_uri);
+						const rpUrl = new URL(resp.data.redirect_uri);
+
+						//To handle audit events that were generated from these RPs before updated to registry was made
+						//https://govukverify.atlassian.net/browse/F2F-958
+						if (!rpUrl.hostname.startsWith("www") &&
+							(rpUrl.hostname === "apply-basic-criminal-record-check.service.gov.uk" || rpUrl.hostname === "vehicle-operator-licensing.service.gov.uk") ) {
+							rpUrl.hostname = "www" + "." + rpUrl.hostname;
+						}
+    					res.redirect(rpUrl.toString());
     				} else {
     					this.redirectToDashboard(res, "Received no data, missing mandatory params in response or statusCode other than 200" );
     				}

--- a/src/tests/unit/controller/ReturnController.test.ts
+++ b/src/tests/unit/controller/ReturnController.test.ts
@@ -72,10 +72,10 @@ describe("returnController test", () => {
 				"code":"abcd123",
 			},
 		};
-		mockedAxios.get.mockResolvedValue({ status:200, data: { "status":"completed", "redirect_uri":"dummy RP url" } });
+		mockedAxios.get.mockResolvedValue({ status:200, data: { "status":"completed", "redirect_uri":"https://apply-hm-armed-forces-veteran-card.service.mod.uk/offline-start" } });
 		await returnCtrl.handleRedirect(mockRequest, mockResponse);
 		expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
-		expect(mockResponse.redirect).toHaveBeenCalledWith("dummy RP url");
+		expect(mockResponse.redirect).toHaveBeenCalledWith("https://apply-hm-armed-forces-veteran-card.service.mod.uk/offline-start");
 	});
 
 	it("handle Redirect and redirect to accounts dashboard as status 'pending'", async () => {
@@ -90,5 +90,61 @@ describe("returnController test", () => {
 		await returnCtrl.handleRedirect(mockRequest, mockResponse);
 		expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
 		expect(mockResponse.redirect).toHaveBeenCalledWith("https://accounts_dashboard_url");
+	});
+
+	it("handle redirect to DBS RP successfully when redirect url does not contain www", async () => {
+
+		const mockRequest = {
+			query:{
+				"state":"471600",
+				"code":"abcd123",
+			},
+		};
+		mockedAxios.get.mockResolvedValue({ status:200, data: { "status":"completed", "redirect_uri":"https://apply-basic-criminal-record-check.service.gov.uk/" } });
+		await returnCtrl.handleRedirect(mockRequest, mockResponse);
+		expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
+		expect(mockResponse.redirect).toHaveBeenCalledWith("https://www.apply-basic-criminal-record-check.service.gov.uk/");
+	});
+
+	it("handle Redirect to DBS RP successfully when redirect url contains www", async () => {
+
+		const mockRequest = {
+			query:{
+				"state":"471600",
+				"code":"abcd123",
+			},
+		};
+		mockedAxios.get.mockResolvedValue({ status:200, data: { "status":"completed", "redirect_uri":"https://www.apply-basic-criminal-record-check.service.gov.uk/" } });
+		await returnCtrl.handleRedirect(mockRequest, mockResponse);
+		expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
+		expect(mockResponse.redirect).toHaveBeenCalledWith('https://www.apply-basic-criminal-record-check.service.gov.uk/');
+	});
+
+	it("handle redirect to DVLA RP successfully when redirect url does not contain www", async () => {
+
+		const mockRequest = {
+			query:{
+				"state":"471600",
+				"code":"abcd123",
+			},
+		};
+		mockedAxios.get.mockResolvedValue({ status:200, data: { "status":"completed", "redirect_uri":"https://vehicle-operator-licensing.service.gov.uk/" } });
+		await returnCtrl.handleRedirect(mockRequest, mockResponse);
+		expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
+		expect(mockResponse.redirect).toHaveBeenCalledWith("https://www.vehicle-operator-licensing.service.gov.uk/");
+	});
+
+	it("handle Redirect to DVLA RP successfully when redirect url contains www", async () => {
+
+		const mockRequest = {
+			query:{
+				"state":"471600",
+				"code":"abcd123",
+			},
+		};
+		mockedAxios.get.mockResolvedValue({ status:200, data: { "status":"completed", "redirect_uri":"https://www.vehicle-operator-licensing.service.gov.uk/" } });
+		await returnCtrl.handleRedirect(mockRequest, mockResponse);
+		expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
+		expect(mockResponse.redirect).toHaveBeenCalledWith('https://www.vehicle-operator-licensing.service.gov.uk/');
 	});
 });

--- a/src/tests/unit/controller/ReturnController.test.ts
+++ b/src/tests/unit/controller/ReturnController.test.ts
@@ -117,7 +117,7 @@ describe("returnController test", () => {
 		mockedAxios.get.mockResolvedValue({ status:200, data: { "status":"completed", "redirect_uri":"https://www.apply-basic-criminal-record-check.service.gov.uk/" } });
 		await returnCtrl.handleRedirect(mockRequest, mockResponse);
 		expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
-		expect(mockResponse.redirect).toHaveBeenCalledWith('https://www.apply-basic-criminal-record-check.service.gov.uk/');
+		expect(mockResponse.redirect).toHaveBeenCalledWith("https://www.apply-basic-criminal-record-check.service.gov.uk/");
 	});
 
 	it("handle redirect to DVLA RP successfully when redirect url does not contain www", async () => {
@@ -145,6 +145,6 @@ describe("returnController test", () => {
 		mockedAxios.get.mockResolvedValue({ status:200, data: { "status":"completed", "redirect_uri":"https://www.vehicle-operator-licensing.service.gov.uk/" } });
 		await returnCtrl.handleRedirect(mockRequest, mockResponse);
 		expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
-		expect(mockResponse.redirect).toHaveBeenCalledWith('https://www.vehicle-operator-licensing.service.gov.uk/');
+		expect(mockResponse.redirect).toHaveBeenCalledWith("https://www.vehicle-operator-licensing.service.gov.uk/");
 	});
 });

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -1,3 +1,7 @@
 export class Constants {
     static readonly ENV_VAR_UNDEFINED = "ENV Variables are undefined";
+
+    static readonly DBS_BASE_URL = "apply-basic-criminal-record-check.service.gov.uk";
+
+    static readonly DVLA_BASE_URL = "vehicle-operator-licensing.service.gov.uk";
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

Apending www before DBS and DVLA urls, if missing, to redirect users to the right RP page

### Why did it change

These particular RP urls were updated in Auth registry later and some of the audit events exist from before that change hence this fix is needed to update the redirection for such DB records

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-1014](https://govukverify.atlassian.net/browse/F2F-1014)

## Checklists

### Testing

Tested by creating docker image with the changes and deploying onto `ipvreturn-front` stack
### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[F2F-1014]: https://govukverify.atlassian.net/browse/F2F-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ