### PR TITLE
[F2F-1132] - Include UTM Parameters in Results Email Link

### DIFF
--- a/src/controller/ReturnController.ts
+++ b/src/controller/ReturnController.ts
@@ -40,7 +40,7 @@ export class ReturnController {
     		loggingHelper.info("Fetching CLIENT_ID from SSM" );
     		ReturnController.clientId = await this.iprService.getParameter(EnvironmentVariables.getClientIdSsmPath());
     	}
-    	const authorizeUrl = `${discoveryEndpoint}/authorize?response_type=code&scope=openid&client_id=${ReturnController.clientId}&state=${state}&redirect_uri=${redirectUri}&nonce=${nonce}`;
+    	const authorizeUrl = `${discoveryEndpoint}/authorize?email=confirmation&response_type=code&scope=openid&client_id=${ReturnController.clientId}&state=${state}&redirect_uri=${redirectUri}&nonce=${nonce}`;
     	loggingHelper.info("Authorize url", { authorizeUrl });
     	return authorizeUrl;
     }

--- a/src/tests/unit/controller/ReturnController.test.ts
+++ b/src/tests/unit/controller/ReturnController.test.ts
@@ -39,7 +39,7 @@ describe("returnController test", () => {
 
 		const actualResult = await returnCtrl.handleResumeReturnAuthUrl();
 		const nonce = (actualResult ).split("nonce=", actualResult.length);
-		expect(actualResult).toBe(`https://discovery/authorize?response_type=code&scope=openid&client_id=mockClientId&state=123456&redirect_uri=https%3A%2F%2Fredirect&nonce=${nonce[1]}`);
+		expect(actualResult).toBe(`https://discovery/authorize?email=confirmation&response_type=code&scope=openid&client_id=mockClientId&state=123456&redirect_uri=https%3A%2F%2Fredirect&nonce=${nonce[1]}`);
 	});
 
 	it("handle Redirect when query params are missing", async () => {


### PR DESCRIPTION
### What changed

Append the ?email=confirmation UTM parameter to the end of the OIDC GET/authorize link that a user is initially redirected to after clicking on the link in the email sent by IPR

### Issue tracking
https://govukverify.atlassian.net/browse/F2F-1132