### PR TITLE
[F2F-661] Adds apigw responseLatency and integrationLatency logs

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -563,7 +563,9 @@ Resources:
           "routeKey":"$context.routeKey",
           "status":"$context.status",
           "protocol":"$context.protocol",
-          "responseLength":"$context.responseLength"
+          "responseLength":"$context.responseLength",
+          "responseLatency":"$context.responseLatency",
+          "integrationLatency":"$context.integrationLatency"
           }
   WAFv2ACLAssociation:
     Type: AWS::WAFv2::WebACLAssociation


### PR DESCRIPTION
## Proposed changes

### What changed

add responseLatency and integrationLatency to FE APIGW Access Log

### Why did it change

assist in reviewing performance test results

### Screenshots
![image](https://github.com/alphagov/di-ipvreturn-front/assets/40401118/06fe439d-f833-4700-9357-290dc54b5560)


### Issue tracking

- [F2F-661](https://govukverify.atlassian.net/browse/F2F-661)


[F2F-661]: https://govukverify.atlassian.net/browse/F2F-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ